### PR TITLE
Define $table_name property

### DIFF
--- a/src/DataObjects/MemberVisit.php
+++ b/src/DataObjects/MemberVisit.php
@@ -7,6 +7,7 @@ use SilverStripe\Security\Member;
 
 class MemberVisit extends DataObject {	
 
+	private static $table_name='MemberVisit';
 	private static $singular_name = 'Member Visit';
 	private static $plural_name = 'Member Visits';
 	private static $description = 'Timestamp of login event for a member';


### PR DESCRIPTION
Table name property should be define as recommanded on DataObject `MemberVisit` to avoid long table name like `PlasticStudio_MemberVisits_MemberVisit`